### PR TITLE
feat: add user secrets module for handling previously updated password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ node_modules
 
 .DS_Store
 
+# jetbrains
+.idea
+
 /dist
 /completions/
 /manpages/

--- a/backend/src/@types/fastify.d.ts
+++ b/backend/src/@types/fastify.d.ts
@@ -31,6 +31,7 @@ import { TSecretSnapshotServiceFactory } from "@app/ee/services/secret-snapshot/
 import { TTrustedIpServiceFactory } from "@app/ee/services/trusted-ip/trusted-ip-service";
 import { TAuthMode } from "@app/server/plugins/auth/inject-identity";
 import { TApiKeyServiceFactory } from "@app/services/api-key/api-key-service";
+import { TAuthCredentialsHistoryFactory } from "@app/services/auth/auth-credential-history-service";
 import { TAuthLoginFactory } from "@app/services/auth/auth-login-service";
 import { TAuthPasswordFactory } from "@app/services/auth/auth-password-service";
 import { TAuthSignupFactory } from "@app/services/auth/auth-signup-service";
@@ -113,6 +114,7 @@ declare module "fastify" {
 
   interface FastifyInstance {
     services: {
+      authCredentialHistory: TAuthCredentialsHistoryFactory;
       login: TAuthLoginFactory;
       password: TAuthPasswordFactory;
       signup: TAuthSignupFactory;

--- a/backend/src/db/migrations/20241026170204_auth-credential-history.ts
+++ b/backend/src/db/migrations/20241026170204_auth-credential-history.ts
@@ -1,0 +1,37 @@
+import { Knex } from "knex";
+
+import { TableName } from "@app/db/schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const isTablePresent = await knex.schema.hasTable(TableName.AuthCredentialHistory);
+  if (!isTablePresent) {
+    await knex.schema.createTable(TableName.AuthCredentialHistory, (t) => {
+      t.uuid("id", { primaryKey: true }).defaultTo(knex.fn.uuid());
+      t.text("clientPublicKey");
+      t.text("serverPrivateKey");
+      t.integer("encryptionVersion").defaultTo(2);
+      t.text("protectedKey");
+      t.text("protectedKeyIV");
+      t.text("protectedKeyTag");
+      t.text("publicKey").notNullable();
+      t.text("encryptedPrivateKey").notNullable();
+      t.text("iv").notNullable();
+      t.text("tag").notNullable();
+      t.text("salt").notNullable();
+      t.text("verifier").notNullable();
+      // one to one relationship
+      t.uuid("userId").notNullable();
+      t.foreign("userId").references("id").inTable(TableName.Users).onDelete("CASCADE");
+      t.text("hashedPassword");
+      t.text("serverEncryptedPrivateKey").notNullable();
+      t.text("serverEncryptedPrivateKeyIV").notNullable();
+      t.text("serverEncryptedPrivateKeyTag").notNullable();
+      t.text("serverEncryptedPrivateKeyEncoding").notNullable();
+      t.timestamp("createdAt").defaultTo(knex.fn.now()).notNullable();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists(TableName.AuthCredentialHistory);
+}

--- a/backend/src/db/schemas/models.ts
+++ b/backend/src/db/schemas/models.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export enum TableName {
   Users = "users",
+  AuthCredentialHistory = "auth_credential_history",
   CertificateAuthority = "certificate_authorities",
   CertificateTemplateEstConfig = "certificate_template_est_configs",
   CertificateAuthorityCert = "certificate_authority_certs",

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -81,6 +81,7 @@ import { readLimit } from "@app/server/config/rateLimiter";
 import { accessTokenQueueServiceFactory } from "@app/services/access-token-queue/access-token-queue";
 import { apiKeyDALFactory } from "@app/services/api-key/api-key-dal";
 import { apiKeyServiceFactory } from "@app/services/api-key/api-key-service";
+import { authCredentialHistoryServiceFactory } from "@app/services/auth/auth-credential-history-service";
 import { authDALFactory } from "@app/services/auth/auth-dal";
 import { authLoginServiceFactory } from "@app/services/auth/auth-login-service";
 import { authPaswordServiceFactory } from "@app/services/auth/auth-password-service";
@@ -106,6 +107,7 @@ import { externalMigrationServiceFactory } from "@app/services/external-migratio
 import { groupProjectDALFactory } from "@app/services/group-project/group-project-dal";
 import { groupProjectMembershipRoleDALFactory } from "@app/services/group-project/group-project-membership-role-dal";
 import { groupProjectServiceFactory } from "@app/services/group-project/group-project-service";
+import { authCredentialHistoryDALFactory } from "@app/services/history/auth-credential-history-dal";
 import { identityDALFactory } from "@app/services/identity/identity-dal";
 import { identityMetadataDALFactory } from "@app/services/identity/identity-metadata-dal";
 import { identityOrgDALFactory } from "@app/services/identity/identity-org-dal";
@@ -339,6 +341,7 @@ export const registerRoutes = async (
   const workflowIntegrationDAL = workflowIntegrationDALFactory(db);
 
   const externalGroupOrgRoleMappingDAL = externalGroupOrgRoleMappingDALFactory(db);
+  const authCredentialHistoryDAL = authCredentialHistoryDALFactory(db);
 
   const permissionService = permissionServiceFactory({
     permissionDAL,
@@ -496,7 +499,8 @@ export const registerRoutes = async (
     tokenService,
     smtpService,
     authDAL,
-    userDAL
+    userDAL,
+    authCredentialHistoryDAL
   });
 
   const projectBotService = projectBotServiceFactory({ permissionService, projectBotDAL, projectDAL });
@@ -1256,6 +1260,8 @@ export const registerRoutes = async (
     externalGroupOrgRoleMappingDAL
   });
 
+  const authCredentialHistoryService = authCredentialHistoryServiceFactory({ userDAL, authCredentialHistoryDAL });
+
   await superAdminService.initServerCfg();
   //
   // setup the communication with license key server
@@ -1268,6 +1274,7 @@ export const registerRoutes = async (
 
   // inject all services
   server.decorate<FastifyZodProvider["services"]>("services", {
+    authCredentialHistory: authCredentialHistoryService,
     login: loginService,
     password: passwordService,
     signup: signupService,

--- a/backend/src/server/routes/sanitizedSchemas.ts
+++ b/backend/src/server/routes/sanitizedSchemas.ts
@@ -10,6 +10,7 @@ import {
   UsersSchema
 } from "@app/db/schemas";
 import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import { maskField } from "@app/utils/mask-data";
 
 import { UnpackedPermissionSchema } from "./santizedSchemas/permission";
 
@@ -100,6 +101,15 @@ export const secretRawSchema = z.object({
   metadata: z.unknown().nullable().optional(),
   createdAt: z.date(),
   updatedAt: z.date()
+});
+
+export const sanitizedPassHistorySchema = z.object({
+  id: z.string(),
+  hashedPassword: z.string().transform(maskField),
+  createdAt: z.date(),
+  email: z.string(),
+  userId: z.string(),
+  username: z.string()
 });
 
 export const ProjectPermissionSchema = z.object({

--- a/backend/src/server/routes/v3/user-router.ts
+++ b/backend/src/server/routes/v3/user-router.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { ApiKeysSchema } from "@app/db/schemas/api-keys";
 import { readLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
+import { sanitizedPassHistorySchema } from "@app/server/routes/sanitizedSchemas";
 import { AuthMode } from "@app/services/auth/auth-type";
 
 export const registerUserRouter = async (server: FastifyZodProvider) => {
@@ -23,6 +24,42 @@ export const registerUserRouter = async (server: FastifyZodProvider) => {
     handler: async (req) => {
       const apiKeyData = await server.services.apiKey.getMyApiKeys(req.permission.id);
       return { apiKeyData };
+    }
+  });
+
+  server.route({
+    method: "GET",
+    url: "/credential-history/:userId",
+    config: { rateLimit: readLimit },
+    schema: {
+      params: z.object({ userId: z.string().trim() }),
+      response: {
+        200: z.object({
+          histories: sanitizedPassHistorySchema.array()
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const histories = await server.services.authCredentialHistory.getCredentialHistory(req.params.userId);
+      return { histories };
+    }
+  });
+
+  server.route({
+    method: "DELETE",
+    url: "/credential-history/:id",
+    config: { rateLimit: readLimit },
+    schema: {
+      params: z.object({ id: z.string().trim() }),
+      response: {
+        200: z.object({ id: z.string() })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const id = await server.services.authCredentialHistory.deleteCredentialHistory(req.params.id);
+      return { id };
     }
   });
 };

--- a/backend/src/services/auth/auth-credential-history-service.ts
+++ b/backend/src/services/auth/auth-credential-history-service.ts
@@ -1,0 +1,30 @@
+import { TAuthCredentialHistoryDALFactory } from "@app/services/history/auth-credential-history-dal";
+
+import { TUserDALFactory } from "../user/user-dal";
+
+type TAuthPasswordServiceFactoryDep = {
+  userDAL: TUserDALFactory;
+  authCredentialHistoryDAL: TAuthCredentialHistoryDALFactory;
+};
+
+export type TAuthCredentialsHistoryFactory = ReturnType<typeof authCredentialHistoryServiceFactory>;
+export const authCredentialHistoryServiceFactory = ({
+  userDAL,
+  authCredentialHistoryDAL
+}: TAuthPasswordServiceFactoryDep) => {
+  const getCredentialHistory = async (userId: string) => {
+    const userEnc = await userDAL.findUserEncKeyByUserId(userId);
+    if (!userEnc) throw new Error("Failed to find user");
+    return authCredentialHistoryDAL.findByUserId(userId);
+  };
+
+  const deleteCredentialHistory = async (historyId: string) => {
+    await authCredentialHistoryDAL.deleteById(historyId);
+    return historyId;
+  };
+
+  return {
+    getCredentialHistory,
+    deleteCredentialHistory
+  };
+};

--- a/backend/src/services/history/auth-credential-history-dal.ts
+++ b/backend/src/services/history/auth-credential-history-dal.ts
@@ -1,0 +1,43 @@
+import { Knex } from "knex";
+
+import { TDbClient } from "@app/db";
+import { TableName, TUserEncryptionKeys } from "@app/db/schemas";
+import { DatabaseError } from "@app/lib/errors";
+import { ormify } from "@app/lib/knex";
+
+export type TAuthCredentialHistoryDALFactory = ReturnType<typeof authCredentialHistoryDALFactory>;
+
+export const authCredentialHistoryDALFactory = (db: TDbClient) => {
+  const authCredentialHistoryOrm = ormify(db, TableName.AuthCredentialHistory);
+
+  const createPasswordHistory = async (data: TUserEncryptionKeys, tx?: Knex): Promise<boolean> => {
+    try {
+      const response = await (tx || db)(TableName.AuthCredentialHistory)
+        .insert({ ...data, id: undefined })
+        .returning("*");
+      return !!response;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Create credentials history" });
+    }
+  };
+
+  const findByUserId = async (userId: string, tx?: Knex) => {
+    return (tx || db)(TableName.AuthCredentialHistory)
+      .where("userId", userId)
+      .join(TableName.Users, `${TableName.AuthCredentialHistory}.userId`, `${TableName.Users}.id`)
+      .select(
+        db.ref("id").withSchema(TableName.AuthCredentialHistory),
+        db.ref("hashedPassword").withSchema(TableName.AuthCredentialHistory),
+        db.ref("createdAt").withSchema(TableName.AuthCredentialHistory),
+        db.ref("email").withSchema(TableName.Users),
+        db.ref("username").withSchema(TableName.Users),
+        db.ref("id").withSchema(TableName.Users).as("userId")
+      );
+  };
+
+  return {
+    ...authCredentialHistoryOrm,
+    createPasswordHistory,
+    findByUserId
+  };
+};

--- a/backend/src/services/user/user-dal.ts
+++ b/backend/src/services/user/user-dal.ts
@@ -98,6 +98,17 @@ export const userDALFactory = (db: TDbClient) => {
     }
   };
 
+  const findUserEncKeyLeanByUserId = async (userId: string, tx?: Knex) => {
+    try {
+      const user = await (tx || db.replicaNode())(TableName.UserEncryptionKey)
+        .where(`${TableName.UserEncryptionKey}.userId`, userId)
+        .first();
+      return user;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Find user enc by user id" });
+    }
+  };
+
   const findUserByProjectMembershipId = async (projectMembershipId: string) => {
     try {
       return await db
@@ -186,6 +197,7 @@ export const userDALFactory = (db: TDbClient) => {
     findUserEncKeyByUsername,
     findUserEncKeyByUserIdsBatch,
     findUserEncKeyByUserId,
+    findUserEncKeyLeanByUserId,
     updateUserEncryptionByUserId,
     findUserByProjectMembershipId,
     findUsersByProjectMembershipIds,

--- a/backend/src/utils/mask-data.ts
+++ b/backend/src/utils/mask-data.ts
@@ -1,0 +1,4 @@
+export const maskField = (value: string) => {
+  if (value.length <= 3) return value;
+  return value.slice(0, 3) + "*".repeat(value.length - 3);
+};

--- a/frontend/public/locales/en/translations.json
+++ b/frontend/public/locales/en/translations.json
@@ -1,4 +1,23 @@
 {
+  "user-secrets": {
+    "title": "User Secrets",
+    "modal": {
+      "update": {
+        "title": "Update credentials",
+        "subtitle": "Avoid to use old passwords"
+      },
+      "delete": {
+        "title": "Delete already used credentials"
+      }
+    },
+    "tabs": {
+      "first-title": "Credential",
+      "first-subtitle": "Credential History"
+    },
+    "btns": {
+      "update-credentials": "Update"
+    }
+  },
   "activity": {
     "title": "Audit Logs",
     "subtitle": "Event history for this Infisical project.",

--- a/frontend/src/hooks/api/users/queries.tsx
+++ b/frontend/src/hooks/api/users/queries.tsx
@@ -13,6 +13,7 @@ import {
   APIKeyData,
   AuthMethod,
   CreateAPIKeyRes,
+  CredentialHistory,
   DeletOrgMembershipDTO,
   OrgUser,
   RenameUserDTO,
@@ -444,5 +445,23 @@ export const useListUserGroupMemberships = (username: string) => {
 
       return data;
     }
+  });
+};
+
+export const useDeleteHistoryCredentials = () => {
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiRequest.delete(`/api/v3/users/credential-history/${id}`);
+    },
+  });
+};
+
+export const useCredentialsHistory = (userId: string) => {
+  return useQuery({
+    queryFn: async () => {
+      const { data } = await apiRequest.get<{ histories: CredentialHistory[] }>(`/api/v3/users/credential-history/${userId}`);
+      return data.histories
+    },
+    enabled: true
   });
 };

--- a/frontend/src/hooks/api/users/types.ts
+++ b/frontend/src/hooks/api/users/types.ts
@@ -191,3 +191,12 @@ export type TokenVersion = {
   createdAt: string;
   updatedAt: string;
 };
+
+export type CredentialHistory = {
+  id: string;
+  hashedPassword: string;
+  createdAt: string;
+  email: string;
+  userId: string;
+  username: string;
+};

--- a/frontend/src/layouts/AppLayout/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout/AppLayout.tsx
@@ -807,6 +807,16 @@ export const AppLayout = ({ children }: LayoutProps) => {
                           </MenuItem>
                         </a>
                       </Link>
+                      <Link href={`/org/${currentOrg?.id}/user-secrets`} passHref>
+                        <a>
+                          <MenuItem
+                            isSelected={router.asPath === `/org/${currentOrg?.id}/user-secrets`}
+                            icon="system-outline-90-lock-closed"
+                          >
+                            User Secrets
+                          </MenuItem>
+                        </a>
+                      </Link>
                     </Menu>
                   )}
                 </div>

--- a/frontend/src/lib/date/date-format.ts
+++ b/frontend/src/lib/date/date-format.ts
@@ -1,0 +1,9 @@
+export const formatDate = (date: Date | string) => {
+  const createdDate = new Date(date);
+  const day: number = createdDate.getDate();
+  const month: number = createdDate.getMonth() + 1;
+  const year: number = createdDate.getFullYear();
+  const formattedDate: string = `${day}/${month}/${year}`;
+
+  return formattedDate;
+};

--- a/frontend/src/pages/org/[id]/user-secrets/index.tsx
+++ b/frontend/src/pages/org/[id]/user-secrets/index.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from "react-i18next";
+import Head from "next/head";
+
+import { UserSecretsPage } from "@app/views/UserSecrets/Page";
+
+export default function UserSecrets() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Head>
+        <title>{t("common.head-title", { title: t("user-secrets.title") })}</title>
+        <link rel="icon" href="/infisical.ico" />
+      </Head>
+      <UserSecretsPage />
+    </>
+  );
+}
+
+UserSecrets.requireAuth = true;

--- a/frontend/src/views/UserSecrets/Page/UserSecretsPage.tsx
+++ b/frontend/src/views/UserSecrets/Page/UserSecretsPage.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useRouter } from "next/router";
+
+import { Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
+import { OrgPermissionActions, OrgPermissionSubjects } from "@app/context";
+import { withPermission } from "@app/hoc";
+import { isTabSection } from "@app/views/Org/Types";
+import { CredentialsHistoryTab } from "@app/views/UserSecrets/Page/components/UsersTab";
+
+export const UserSecretsPage = withPermission(
+  () => {
+    const router = useRouter();
+    const { t } = useTranslation();
+
+    const { query } = router;
+
+    const selectedTab = query.selectedTab as string;
+    const tabs = [
+      { name: t("user-secrets.tabs.first-title"), key: "first-tab", comp: () => <CredentialsHistoryTab /> },
+    ];
+    const [activeTab, setActiveTab] = useState(tabs[0].key);
+
+    useEffect(() => {
+      if (selectedTab && isTabSection(selectedTab)) {
+        setActiveTab(selectedTab);
+      }
+    }, [isTabSection, selectedTab]);
+
+    const updateSelectedTab = (tab: string) => {
+      router.push({
+        pathname: router.pathname,
+        query: { ...router.query, selectedTab: tab },
+      });
+    }
+
+    return (
+      <div className="container mx-auto flex flex-col justify-between bg-bunker-800 text-white">
+        <div className="mx-auto mb-6 w-full max-w-7xl py-6 px-6">
+          <p className="mr-4 mb-4 text-3xl font-semibold text-white">{t("user-secrets.title")}</p>
+          <Tabs value={activeTab} onValueChange={updateSelectedTab}>
+            <TabList>
+              {tabs.map(tab => <Tab value={tab.key} key={tab.name}>{tab.name}</Tab>)}
+            </TabList>
+            {tabs.map(tab => (<TabPanel value={tab.key} key={tab.name}>{tab.comp()}</TabPanel>))}
+          </Tabs>
+        </div>
+      </div>
+    );
+  },
+  { action: OrgPermissionActions.Read, subject: OrgPermissionSubjects.Member }
+);

--- a/frontend/src/views/UserSecrets/Page/components/UsersTab/CredentialsHistoryTab.tsx
+++ b/frontend/src/views/UserSecrets/Page/components/UsersTab/CredentialsHistoryTab.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from "react-i18next";
+import { faEdit } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { motion } from "framer-motion";
+
+import { createNotification } from "@app/components/notifications";
+import { OrgPermissionCan } from "@app/components/permissions";
+import { Button, DeleteActionModal } from "@app/components/v2";
+import { OrgPermissionActions, OrgPermissionSubjects, useUser } from "@app/context";
+import { useCredentialsHistory, useDeleteHistoryCredentials } from "@app/hooks/api/users/queries";
+import { usePopUp } from "@app/hooks/usePopUp";
+
+import { HistoryTable } from "./HistoryTable";
+import { UpdateCredentialsModal } from "./UpdateCredentialsModal";
+
+export const CredentialsHistoryTab = () => {
+  const { t } = useTranslation();
+  const { popUp, handlePopUpOpen, handlePopUpToggle, handlePopUpClose } = usePopUp([ "updateWebLogin", "removeHistory"]);
+  const { user } = useUser();
+  const { data: histories, isLoading, refetch } = useCredentialsHistory(user.id);
+  const { mutateAsync: deleteHistory } = useDeleteHistoryCredentials();
+
+  const handleUpdateClick = () => handlePopUpOpen("updateWebLogin");
+
+  const handleRemoveClick = async (): Promise<void> => {
+    try {
+      const { id } = popUp?.removeHistory?.data as { id: string };
+      await deleteHistory(id);
+      await refetch();
+      handlePopUpClose("removeHistory");
+      createNotification({ type: "success", text: "Successfully deleted user" });
+    } catch (err) {
+      createNotification({ type: "error", text: "Error deleting user" });
+    }
+  };
+
+  return (
+    <motion.div
+      key="panel-org-members"
+      transition={{ duration: 0.15 }}
+      initial={{ opacity: 0, translateX: 30 }}
+      animate={{ opacity: 1, translateX: 0 }}
+      exit={{ opacity: 0, translateX: 30 }}
+    >
+      <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+        <div className="mb-4 flex justify-between">
+          <p className="text-xl font-semibold text-mineshaft-100">{t("user-secrets.tabs.first-subtitle")}</p>
+          <OrgPermissionCan I={OrgPermissionActions.Create} a={OrgPermissionSubjects.Member}>
+            {(isAllowed) => (
+              <Button
+                colorSchema="primary"
+                type="submit"
+                leftIcon={<FontAwesomeIcon icon={faEdit} />}
+                onClick={handleUpdateClick}
+                isDisabled={!isAllowed}
+              >
+                {t("user-secrets.btns.update-credentials")}
+              </Button>
+            )}
+          </OrgPermissionCan>
+        </div>
+        <HistoryTable handlePopUpOpen={handlePopUpOpen} data={histories} isLoading={isLoading} />
+        <UpdateCredentialsModal popUp={popUp} handlePopUpToggle={handlePopUpToggle} />
+        <DeleteActionModal
+          isOpen={popUp.removeHistory.isOpen}
+          deleteKey="remove"
+          title={t("user-secrets.btns.update-credentials")}
+          onChange={(isOpen) => handlePopUpToggle("removeHistory", isOpen)}
+          onDeleteApproved={handleRemoveClick}
+        />
+      </div>
+    </motion.div>
+  );
+};
+

--- a/frontend/src/views/UserSecrets/Page/components/UsersTab/HistoryTable.tsx
+++ b/frontend/src/views/UserSecrets/Page/components/UsersTab/HistoryTable.tsx
@@ -1,0 +1,70 @@
+import { faKey, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import {
+  EmptyState,
+  IconButton,
+  Table,
+  TableContainer,
+  TableSkeleton,
+  TBody,
+  Td,
+  Th,
+  THead,
+  Tr
+} from "@app/components/v2";
+import { CredentialHistory } from "@app/hooks/api/users/types";
+import { UsePopUpState } from "@app/hooks/usePopUp";
+import { formatDate } from "@app/lib/date/date-format";
+
+type Props = {
+  data?: CredentialHistory[]
+  handlePopUpOpen: (
+    popUpName: keyof UsePopUpState<["removeHistory"]>,
+    data: { id: string; }
+  ) => void;
+  isLoading: boolean
+};
+
+export const HistoryTable = ({ handlePopUpOpen, data, isLoading }: Props) => (
+  <TableContainer className="mt-4">
+    <Table>
+      <THead>
+        <Tr>
+          <Th>Login</Th>
+          <Th>Password</Th>
+          <Th>Created At</Th>
+          <Th className="w-5" />
+        </Tr>
+      </THead>
+      <TBody>
+        {isLoading && <TableSkeleton columns={5} innerKey="org-members" />}
+        {data?.map((item) => (
+          <Tr className="h-10 w-full transition-colors duration-100 hover:bg-mineshaft-700" key={item.id}>
+            <Td className="text-mineshaft-400">{item.username}</Td>
+            <Td className="text-mineshaft-400">{item.hashedPassword}</Td>
+            <Td>{formatDate(item.createdAt)}</Td>
+            <Td>
+              <IconButton
+                size="lg"
+                colorSchema="danger"
+                variant="plain"
+                ariaLabel="update"
+                onClick={() => handlePopUpOpen("removeHistory", { id: item.id })}
+              >
+                <FontAwesomeIcon icon={faTrash} />
+              </IconButton>
+            </Td>
+          </Tr>
+        ))}
+        {!isLoading && !data?.length && (
+          <Tr>
+            <Td colSpan={3}>
+              <EmptyState title="No credential history found" icon={faKey} />
+            </Td>
+          </Tr>
+        )}
+      </TBody>
+    </Table>
+  </TableContainer>
+)

--- a/frontend/src/views/UserSecrets/Page/components/UsersTab/UpdateCredentialsModal.tsx
+++ b/frontend/src/views/UserSecrets/Page/components/UsersTab/UpdateCredentialsModal.tsx
@@ -1,0 +1,145 @@
+import { Controller, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { createNotification } from "@app/components/notifications";
+import attemptChangePassword from "@app/components/utilities/attemptChangePassword";
+import {
+  Button,
+  FormControl, Input,
+  Modal,
+  ModalContent,
+} from "@app/components/v2";
+import { useOrganization, useUser } from "@app/context";
+import { UsePopUpState } from "@app/hooks/usePopUp";
+
+const userChangeWebLoginSchema = z
+  .object({
+    currentPassword: z.string().min(12),
+    newPassword: z
+      .string()
+      .refine((newPassword) => /[A-Z]/.test(newPassword), {
+        message: "Password should contain at least 1 uppercase",
+      })
+      .refine((newPassword) => /[a-z]/.test(newPassword), {
+        message: "Password should contain at least 1 lowercase",
+      })
+      .refine((newPassword) => /[0-9]/.test(newPassword), {
+        message: "Password should contain at least 1 number",
+      })
+      .refine((newPassword) => /[!@#$%^&*.]/.test(newPassword), {
+        message: "Password should contain at least 1 special character",
+      })
+      .refine((newPassword) => newPassword.length >= 12, {
+        message: "Password should contain at least 8 characters",
+      }),
+    newPasswordConfirmation: z.string(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.newPasswordConfirmation !== data.newPassword) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Mismatching passwords", path: ["newPasswordConfirmation"] });
+    }
+
+    if (data.currentPassword === data.newPassword) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "It's the same password", path: ["currentPassword"] });
+    }
+  });
+
+type TUpdateWebLoginForm = z.infer<typeof userChangeWebLoginSchema>;
+
+type Props = {
+  popUp: UsePopUpState<["updateWebLogin"]>;
+  handlePopUpToggle: (popUpName: keyof UsePopUpState<["updateWebLogin"]>, state?: boolean) => void;
+};
+
+export const UpdateCredentialsModal = ({ popUp, handlePopUpToggle }: Props) => {
+  const { t } = useTranslation();
+  const { user } = useUser();
+  const { currentOrg } = useOrganization();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isSubmitting }
+  } = useForm<TUpdateWebLoginForm>({ resolver: zodResolver(userChangeWebLoginSchema) });
+
+  const onAddMembers = async ({
+    newPassword,
+    currentPassword
+  }: TUpdateWebLoginForm) => {
+    if (!currentOrg?.id) return;
+
+    try {
+      await attemptChangePassword({ email: user.username, currentPassword, newPassword });
+      createNotification({ text: "Successfully updated information", type: "success"});
+      window.location.href = "/login";
+    } catch (e) {
+      createNotification({ text: "Was not possible to update the information.", type: "error"});
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={popUp?.updateWebLogin?.isOpen}
+      onOpenChange={(isOpen) => {
+        handlePopUpToggle("updateWebLogin", isOpen);
+      }}
+    >
+      <ModalContent
+        title={`${t("user-secrets.modal.update.title")}`}
+        subTitle={t("user-secrets.modal.update.subtitle")}
+      >
+        <form onSubmit={handleSubmit(onAddMembers)}>
+          <Controller
+            control={control}
+            name="newPassword"
+            render={({ field, fieldState: { error } }) => (
+              <FormControl
+                label="New password"
+                errorText={error?.message}
+                isError={Boolean(error)}
+              >
+                <Input {...field} placeholder="New password" type="password" />
+              </FormControl>
+            )}
+          />
+          <Controller
+            control={control}
+            name="newPasswordConfirmation"
+            render={({ field, fieldState: { error } }) => (
+              <FormControl
+                label="New password confirmation"
+                errorText={error?.message}
+                isError={Boolean(error)}
+              >
+                <Input {...field} placeholder="New password confirmation" type="password" />
+              </FormControl>
+            )}
+          />
+          <Controller
+            control={control}
+            name="currentPassword"
+            render={({ field, fieldState: { error } }) => (
+              <FormControl
+                label="Current password"
+                errorText={error?.message}
+                isError={Boolean(error)}
+              >
+                <Input {...field} placeholder="Your current password" type="password" />
+              </FormControl>
+            )}
+          />
+          <div className="mt-8 flex items-center">
+            <Button className="mr-4" size="sm" type="submit" isLoading={isSubmitting} isDisabled={isSubmitting}>
+              Save
+            </Button>
+            <Button colorSchema="secondary" variant="plain" onClick={() => handlePopUpToggle("updateWebLogin", false)}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/frontend/src/views/UserSecrets/Page/components/UsersTab/index.tsx
+++ b/frontend/src/views/UserSecrets/Page/components/UsersTab/index.tsx
@@ -1,0 +1,1 @@
+export { CredentialsHistoryTab } from "./CredentialsHistoryTab";

--- a/frontend/src/views/UserSecrets/Page/index.tsx
+++ b/frontend/src/views/UserSecrets/Page/index.tsx
@@ -1,0 +1,1 @@
+export { UserSecretsPage } from "./UserSecretsPage";


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Take-Home
### Summary
Improvements on upload password page and added a new section for rendering old hashed passwords, after update password the backend will saves a registry in `auth-credential-history` table, so it's possible to see a list of old hashed passwords, update the current one and delete all of them.

## Type ✨

- [ ] Bug fix
- [X] New feature
- [X] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

You have ways to test and validate this section, by updating the password by the normal way and by accessing  a new menu item called "User secrets".

```sh
# Here's some code block to paste some code snippets
```

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->